### PR TITLE
Fixed machine specific asset location reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Tetris
-Tetris game made with the PyGame library in Python.
+Tetris game made with the Pygame library in Python.
 
 
 ## Installing
@@ -12,7 +12,7 @@ pip3 install pygame
 
 
 Another alternative would be to import the contents of the repository in a PyCharm project.
-The PyGame library can be installed in a virtual environment of PyCharm using the steps mentioned [here](https://www.jetbrains.com/help/pycharm/installing-uninstalling-and-upgrading-packages.html).
+The Pygame library can be installed in a virtual environment of PyCharm using the steps mentioned [here](https://www.jetbrains.com/help/pycharm/installing-uninstalling-and-upgrading-packages.html).
 
 
 ## Running the application

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ Download the source code from the repository and run the file just as any other 
 python3 Tetris.py
 ```
 
-If the project is imported in PyCharm, then the file can be run directly by setting the appropriate configurations.
-
-###### Note: The ```filepath``` and ```fontpath``` for the text files and fonts need to be updated according to the location of the project on the user's machine.
-
-
 ## Screenshots
 
 ![1](https://github.com/rajatdiptabiswas/tetris-pygame/blob/master/screenshot-start.png)
@@ -38,8 +33,6 @@ If the project is imported in PyCharm, then the file can be run directly by sett
 ## Prerequisites
 * [Python](https://www.python.org)
 * [Pygame](https://www.pygame.org/wiki/GettingStarted), an open source Python library for making multimedia applications
-* [PyCharm](https://www.jetbrains.com/pycharm/), an integrated development environment for the Python language developed by JetBrains
-
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Tetris
-Tetris game made with the Pygame library in Python.
+Tetris game made with the PyGame library in Python.
 
 
 ## Installing
@@ -12,7 +12,7 @@ pip3 install pygame
 
 
 Another alternative would be to import the contents of the repository in a PyCharm project.
-The Pygame library can be installed in a virtual environment of PyCharm using the steps mentioned [here](https://www.jetbrains.com/help/pycharm/installing-uninstalling-and-upgrading-packages.html).
+The PyGame library can be installed in a virtual environment of PyCharm using the steps mentioned [here](https://www.jetbrains.com/help/pycharm/installing-uninstalling-and-upgrading-packages.html).
 
 
 ## Running the application

--- a/Tetris.py
+++ b/Tetris.py
@@ -30,9 +30,9 @@ block_size = 30  # size of block
 top_left_x = (s_width - play_width) // 2
 top_left_y = s_height - play_height - 50
 
-filepath = './highscore.txt'
-fontpath = './arcade.ttf'
-fontpath_mario = './mario.ttf'
+filepath = '/Users/rajat/PycharmProjects/Tetris/highscore.txt'
+fontpath = '/Users/rajat/PycharmProjects/Tetris/arcade.ttf'
+fontpath_mario = '/Users/rajat/PycharmProjects/Tetris/mario.ttf'
 
 # shapes formats
 

--- a/Tetris.py
+++ b/Tetris.py
@@ -30,9 +30,9 @@ block_size = 30  # size of block
 top_left_x = (s_width - play_width) // 2
 top_left_y = s_height - play_height - 50
 
-filepath = '/Users/rajat/PycharmProjects/Tetris/highscore.txt'
-fontpath = '/Users/rajat/PycharmProjects/Tetris/arcade.ttf'
-fontpath_mario = '/Users/rajat/PycharmProjects/Tetris/mario.ttf'
+filepath = './highscore.txt'
+fontpath = './arcade.ttf'
+fontpath_mario = './mario.ttf'
 
 # shapes formats
 


### PR DESCRIPTION
Changed:
filepath = '/Users/rajat/PycharmProjects/Tetris/highscore.txt'
fontpath = '/Users/rajat/PycharmProjects/Tetris/arcade.ttf'
fontpath_mario = '/Users/rajat/PycharmProjects/Tetris/mario.ttf'

to:
filepath = './highscore.txt'
fontpath = './arcade.ttf'
fontpath_mario = './mario.ttf'

Also fixed references to PyCharm and machine-specific references in README.md. 
This allows the code to be downloaded and simply run, as described in README.md.

Cheers.